### PR TITLE
Feature/1967 monthly ticks on x axis (#316)

### DIFF
--- a/src/scenes/t19/components/HeatTransportController.tsx
+++ b/src/scenes/t19/components/HeatTransportController.tsx
@@ -6,8 +6,10 @@ import {
 } from 'semantic-ui-react';
 import {HeatTransportInput, HeatTransportResults} from './index';
 import {IHeatTransportRequest, IHeatTransportRequestOptions, IHtm} from '../../../core/model/htm/Htm.type';
+import {IRootReducer} from '../../../reducers';
 import {includes} from 'lodash';
 import {makeHeatTransportRequest} from '../../../services/api';
+import {useSelector} from 'react-redux';
 import Htm from '../../../core/model/htm/Htm';
 import HtmInput from '../../../core/model/htm/HtmInput';
 import React, {FormEvent, useEffect, useState} from 'react';
@@ -24,6 +26,8 @@ const HeatTransportController = (props: IProps) => {
     const [activeInput, setActiveInput] = useState<string>();
     const [activeValue, setActiveValue] = useState<string>('');
     const [requestOptions, setRequestOptions] = useState<IHeatTransportRequestOptions>(props.htm.options);
+
+    const user = useSelector((state: IRootReducer) => state.user);
 
     useEffect(() => {
         setRequestOptions(props.htm.options);
@@ -96,6 +100,7 @@ const HeatTransportController = (props: IProps) => {
                     <Grid.Row>
                         <Grid.Column width={8}>
                             <HeatTransportInput
+                                dateTimeFormat={user.settings.dateFormat}
                                 input={props.htm.inputSw}
                                 label="Surface water"
                                 name="sw"
@@ -105,6 +110,7 @@ const HeatTransportController = (props: IProps) => {
                         </Grid.Column>
                         <Grid.Column width={8}>
                             <HeatTransportInput
+                                dateTimeFormat={user.settings.dateFormat}
                                 input={props.htm.inputGw}
                                 label="Groundwater"
                                 name="gw"
@@ -152,7 +158,7 @@ const HeatTransportController = (props: IProps) => {
                     </Grid.Row>
                 </Grid>
             </Form>
-            {props.htm.results && <HeatTransportResults results={props.htm.results}/>}
+            {props.htm.results && <HeatTransportResults dateTimeFormat={user.settings.dateFormat} results={props.htm.results}/>}
         </React.Fragment>
     );
 };

--- a/src/scenes/t19/components/HeatTransportInput.tsx
+++ b/src/scenes/t19/components/HeatTransportInput.tsx
@@ -18,6 +18,7 @@ import React, {SyntheticEvent, useEffect, useState} from 'react';
 import uuid from 'uuid';
 
 interface IProps {
+    dateTimeFormat: string;
     input: HtmInput;
     label: string;
     name: string;
@@ -253,6 +254,7 @@ const HeatTransportInput = (props: IProps) => {
                 />
                 <HeatTransportInputChart
                     data={data}
+                    dateTimeFormat={props.dateTimeFormat}
                     tempTime={tempTime}
                     timesteps={timesteps}
                     isLoading={isFetching}

--- a/src/scenes/t19/components/HeatTransportInputChart.tsx
+++ b/src/scenes/t19/components/HeatTransportInputChart.tsx
@@ -1,13 +1,14 @@
 import {IDateTimeValue} from '../../../core/model/rtm/Sensor.type';
 import {IHeatTransportInput} from '../../../core/model/htm/Htm.type';
 import {LTOB} from 'downsample';
-import {ReferenceLine, ResponsiveContainer, Scatter, ScatterChart, XAxis, YAxis} from 'recharts';
+import {ResponsiveContainer, Scatter, ScatterChart, XAxis, YAxis} from 'recharts';
 import {Segment} from 'semantic-ui-react';
 import React from 'react';
 import moment from 'moment';
 
 interface IProps {
     data?: IHeatTransportInput['data'],
+    dateTimeFormat: string,
     tempTime?: [number, number],
     timesteps?: number[],
     isLoading: boolean
@@ -22,13 +23,14 @@ const HeatTransportInputChart = (props: IProps) => {
                 </ResponsiveContainer>
             </Segment>
         );
-
     }
 
-    const {tempTime, timesteps} = props;
-
     const formatDateTimeTicks = (dt: number) => {
-        return moment.unix(dt).format('YYYY-MM-DD');
+        return moment.unix(dt).format(props.dateTimeFormat);
+    };
+
+    const formatTemperatureTicks = (t: number) => {
+        return t.toFixed(2);
     };
 
     const downSampleData = (d: IDateTimeValue[]) => d ? LTOB(d.map((ds) => ({
@@ -47,30 +49,17 @@ const HeatTransportInputChart = (props: IProps) => {
                     <XAxis
                         dataKey={'x'}
                         domain={[props.data[0].timeStamp, props.data[downsampledData.length - 1].timeStamp]}
-                        name={'Date Time'}
+                        name={'x'}
                         tickFormatter={formatDateTimeTicks}
                         type={'number'}
                     />
                     <YAxis
-                        label={{value: 'T', angle: -90, position: 'insideLeft'}}
+                        label={{value: 'T [°C]', angle: -90, position: 'insideLeft'}}
                         dataKey={'y'}
-                        name={''}
+                        name={'y'}
+                        tickFormatter={formatTemperatureTicks}
                         domain={['auto', 'auto']}
                     />
-                    {tempTime && timesteps &&
-                    <ReferenceLine
-                        x={timesteps[tempTime[0]]}
-                        stroke="#000"
-                        strokeDasharray="3 3"
-                    />
-                    }
-                    {tempTime && timesteps &&
-                    <ReferenceLine
-                        x={timesteps[tempTime[1]]}
-                        stroke="#000"
-                        strokeDasharray="3 3"
-                    />
-                    }
                     <Scatter
                         data={downsampledData}
                         line={{strokeWidth: 2, stroke: '#3498DB'}}


### PR DESCRIPTION
* Feature/1946 - Add points to results charts

* Add min, max and turning-points
* Fix saving meta data

* Feature/1967 - Monthly ticks on x-axis

* Add monthly ticks and tooltips to results charts in t19
* Use custom datetime format from user settings

* Feature/1967 - T19 improvements

* Show only R2 and RMSE in "goodness of fit"-parameters
* Change order of graphs