### PR TITLE
Feature/1947 - T19: Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.idea
+/.vscode

--- a/src/scenes/t19/components/HeatTransportController.tsx
+++ b/src/scenes/t19/components/HeatTransportController.tsx
@@ -135,7 +135,7 @@ const HeatTransportController = () => {
                                     <Form.Input
                                         disabled={isFetching || readOnly}
                                         name="retardationFactor"
-                                        label="Thermal retardation factor"
+                                        label="Thermal Retardation Factor"
                                         type="number"
                                         onBlur={handleBlurInput}
                                         onChange={handleChangeInput}

--- a/src/scenes/t19/components/HeatTransportInputChart.tsx
+++ b/src/scenes/t19/components/HeatTransportInputChart.tsx
@@ -39,7 +39,7 @@ const HeatTransportInputChart = (props: IProps) => {
     })), 500) as DataPoint[] : [];
   };
 
-  const downsampledData = downSampleData(props.data);
+  const downSampledData = downSampleData(props.data);
 
   const RENDER_NO_SHAPE = () => null;
 
@@ -49,7 +49,7 @@ const HeatTransportInputChart = (props: IProps) => {
         <ScatterChart>
           <XAxis
             dataKey={'x'}
-            domain={[props.data[0].timeStamp, props.data[downsampledData.length - 1].timeStamp]}
+            domain={[props.data[0].timeStamp, props.data[downSampledData.length - 1].timeStamp]}
             name={'x'}
             tickFormatter={formatDateTimeTicks}
             type={'number'}
@@ -62,7 +62,7 @@ const HeatTransportInputChart = (props: IProps) => {
             domain={['auto', 'auto']}
           />
           <Scatter
-            data={downsampledData}
+            data={downSampledData}
             line={{strokeWidth: 2, stroke: '#3498db'}}
             lineType={'joint'}
             name={'p'}

--- a/src/scenes/t19/components/HeatTransportResultLineChart.tsx
+++ b/src/scenes/t19/components/HeatTransportResultLineChart.tsx
@@ -9,7 +9,7 @@ import {
 } from 'recharts';
 import {IHeatTransportResults} from '../../../core/model/htm/Htm.type';
 import {SemanticCOLORS} from 'semantic-ui-react/dist/commonjs/generic';
-import {calculateDomain} from './helpers';
+import {calculateDomain, formatLabel} from './helpers';
 import CustomTooltip from './CustomTooltip';
 import React, {useEffect, useState} from 'react';
 import moment from 'moment';
@@ -122,7 +122,7 @@ const HeatTransportResultChart = (props: IProps) => {
                                 fontSize={12}
                                 offset={5}
                                 position="top"
-                                value={point.type}
+                                value={formatLabel(point.type)}
                             />
                         }
                         x={point.x}

--- a/src/scenes/t19/components/HeatTransportResultLineChart.tsx
+++ b/src/scenes/t19/components/HeatTransportResultLineChart.tsx
@@ -104,11 +104,11 @@ const HeatTransportResultChart = (props: IProps) => {
                     label={{value: 'T [°C]', angle: -90, position: 'insideLeft'}}
                     tickFormatter={formatTemperatureTicks}
                 />
-                <Line dot={false} type="monotone" dataKey="obs" stroke="#db3434" strokeWidth={2}/>
-                <Line dot={false} type="monotone" dataKey="sim" stroke="#3498DB" strokeWidth={2}/>
+                <Line dot={false} type="monotone" dataKey="obs" stroke="#3498DB" strokeWidth={2}/>
+                <Line dot={false} type="monotone" dataKey="sim" stroke="#db3434" strokeWidth={2}/>
                 <Tooltip content={
                     <CustomTooltip
-                        colors={{obs: '#db3434', sim: '#3498DB'}}
+                        colors={{obs: '#3498DB', sim: '#db3434'}}
                         dateTimeFormat={props.dateTimeFormat}
                     />
                 }

--- a/src/scenes/t19/components/HeatTransportResults.tsx
+++ b/src/scenes/t19/components/HeatTransportResults.tsx
@@ -1,6 +1,6 @@
 import {Button, Checkbox, Icon, Menu, MenuItemProps, Segment, Table} from 'semantic-ui-react';
 import {IHeatTransportResults} from '../../../core/model/htm/Htm.type';
-import {calculateDomain} from './helpers';
+import {calculateDomain, formatLabel} from './helpers';
 import {downloadFile} from '../../shared/simpleTools/helpers';
 import HeatTransportResultLineChart from './HeatTransportResultLineChart';
 import React, {MouseEvent, useEffect, useState} from 'react';
@@ -210,7 +210,7 @@ const HeatTransportResults = (props: IProps) => {
 
                         return (
                             <Table.Row key={key}>
-                                <Table.Cell>{traveltime.point_type}</Table.Cell>
+                                <Table.Cell>{formatLabel(traveltime.point_type)}</Table.Cell>
                                 <Table.Cell>{keySw.length > 0 ? traveltime[keySw[0]] : 'NULL'}</Table.Cell>
                                 <Table.Cell>{keyGw.length > 0 ? traveltime[keyGw[0]] : 'NULL'}</Table.Cell>
                                 <Table.Cell>{Math.ceil(traveltime.traveltime_thermal_days)}</Table.Cell>

--- a/src/scenes/t19/components/HeatTransportResults.tsx
+++ b/src/scenes/t19/components/HeatTransportResults.tsx
@@ -167,10 +167,8 @@ const HeatTransportResults = (props: IProps) => {
                     {keys.map((name, key) => (
                         <Table.Row key={key}>
                             <Table.Cell>{name}</Table.Cell>
-                            {/* eslint-disable-next-line no-prototype-builtins */}
-                            <Table.Cell>{dataSw[0].hasOwnProperty(name) ? dataSw[0][name].toFixed(digits) : 'NULL'}</Table.Cell>
-                            {/* eslint-disable-next-line no-prototype-builtins */}
-                            <Table.Cell>{dataGw[0].hasOwnProperty(name) ? dataGw[0][name].toFixed(digits) : 'NULL'}</Table.Cell>
+                            <Table.Cell>{name in dataSw[0] ? dataSw[0][name].toFixed(digits) : 'NULL'}</Table.Cell>
+                            <Table.Cell>{name in dataGw[0] ? dataGw[0][name].toFixed(digits) : 'NULL'}</Table.Cell>
                         </Table.Row>
                     ))}
                 </Table.Body>
@@ -215,8 +213,8 @@ const HeatTransportResults = (props: IProps) => {
                                 <Table.Cell>{traveltime.point_type}</Table.Cell>
                                 <Table.Cell>{keySw.length > 0 ? traveltime[keySw[0]] : 'NULL'}</Table.Cell>
                                 <Table.Cell>{keyGw.length > 0 ? traveltime[keyGw[0]] : 'NULL'}</Table.Cell>
-                                <Table.Cell>{traveltime.traveltime_thermal_days.toFixed(0)}</Table.Cell>
-                                <Table.Cell>{traveltime.traveltime_hydraulic_days.toFixed(0)}</Table.Cell>
+                                <Table.Cell>{Math.ceil(traveltime.traveltime_thermal_days)}</Table.Cell>
+                                <Table.Cell>{Math.ceil(traveltime.traveltime_hydraulic_days)}</Table.Cell>
                             </Table.Row>
                         );
                     })}
@@ -294,7 +292,7 @@ const HeatTransportResults = (props: IProps) => {
                 <Menu.Item
                     active={activeIndex === 3}
                     index={3}
-                    name="Sine Fit Results"
+                    name="Results"
                     onClick={handleClickMenuItem}
                 />
             </Menu>

--- a/src/scenes/t19/components/helpers.ts
+++ b/src/scenes/t19/components/helpers.ts
@@ -1,4 +1,4 @@
-import {SemanticCOLORS} from 'semantic-ui-react/dist/commonjs/generic';
+import { SemanticCOLORS } from 'semantic-ui-react/dist/commonjs/generic';
 import _ from 'lodash';
 
 interface IReferencePoint {
@@ -21,4 +21,15 @@ export const calculateDomain = (
     const xMax = data[data.length - 1].x > pointsOrderedByX[pointsOrderedByX.length - 1].x ?
         data[data.length - 1].x : pointsOrderedByX[pointsOrderedByX.length - 1].x;
     return [xMin, xMax];
+};
+
+export const formatLabel = (label: string) => {
+    label = label.replace(/_|-/g, ' ');
+    label = label.replace(
+        /\w\S*/g,
+        (txt: string) => {
+            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+        }
+    );
+    return label;
 };


### PR DESCRIPTION
- keep consistency in labeling, i.e. each word starts with a capital letter
- invert colors for results graphs (consistency with graphs above: measured data = blue, simulated data = red)
- replace "Sine Fit Results" simply with "Results"
- roundup to integer values in Residence Time columns (102.7251 days becomes 103 days)